### PR TITLE
Array merge fix in File.php

### DIFF
--- a/lib/FroalaEditor/File.php
+++ b/lib/FroalaEditor/File.php
@@ -29,7 +29,7 @@ class File {
     if (is_null($options)) {
       $options = File::$defaultUploadOptions;
     } else {
-      $options = array_merge(File::$defaultUploadOptions, $options);
+      $options = array_merge_recursive(File::$defaultUploadOptions, $options);
     }
 
     return DiskManagement::upload($fileRoute, $options);


### PR DESCRIPTION
Changed `array_merge()` to `array_merge_recursive()` to properly merge the two multidimensional arrays.
To prevent that `fieldname` becomes an array the `options` parameter if used in the call to `FroalaEditor_File::upload()` should only contain the `validation` array.
For example:
```
        $options = array(
            //'fieldname' => 'file',
            'validation' => array(
                'allowedExts' => array('csv', 'docx', 'zip'),
                'allowedMimeTypes' => array('text/csv', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'application/zip')
            )
        );
        $response = FroalaEditor_File::upload($target_dir, $options);
```