### PR TITLE
Bug fix and warnings

### DIFF
--- a/lib/FroalaEditor/Utils/Utils.php
+++ b/lib/FroalaEditor/Utils/Utils.php
@@ -6,10 +6,10 @@ class Utils {
   /**
    * Check if file is matching the specified allowed extensions and mime types.
    *
-   * @param $filename string
+   * @param $filename array
    * @param $mimeType string
-   * @param $allowedExts Array
-   * @param $allowedMimeTypes Array
+   * @param $allowedExts array
+   * @param $allowedMimeTypes array
    *
    * @return boolean
    */

--- a/lib/FroalaEditor/Utils/Utils.php
+++ b/lib/FroalaEditor/Utils/Utils.php
@@ -22,7 +22,7 @@ class Utils {
     // Get extension.
     $extension = end($filename);
 
-    return in_array(strtolower($mimeType), $allowedMimeTypes) && in_array(strtolower($extension), $allowedExts);
+    return in_array(strtolower($mimeType), $allowedMimeTypes) && in_array(strtolower($extension), $allowedExts, true);
   }
 
   /**


### PR DESCRIPTION
The bad parameter types in the function docs may raise warnings even with the code correct so I changed it to the correct types.
Also, the in_array should use the 3rd parameter (strict compare) as it may give you crazy values:
http://php.net/manual/pt_BR/function.in-array.php#106319

Discussion:
https://github.com/froala/wysiwyg-editor-php-sdk/issues/16