### PR TITLE
add PHP version and extension requirementss

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
       "role": "Maintainer"
     }
   ],
-  "require": {},
+  "require": {
+    "php": ">=5.4.0",
+    "ext-fileinfo": "*",
+    "ext-imagick": "*"
+  },
   "autoload": {
     "psr-0": {
         "FroalaEditor": "lib/"


### PR DESCRIPTION
It might be a good idea to break off a v2 as well after this, and switch the minimum version support to PHP 7.2