### PR TITLE
Correct URL for other regions

### DIFF
--- a/lib/FroalaEditor/S3.php
+++ b/lib/FroalaEditor/S3.php
@@ -92,7 +92,7 @@ class S3 {
     // Prepare response.
     $response = new \StdClass;
     $response->bucket = $bucket;
-    $response->region = $region != 'us-east-1' ? 's3-' . $region : 's3';
+    $response->region = $region != 'us-east-1' ? 's3.' . $region : 's3';
     $response->keyStart = $keyStart;
 
     // Prepare params.


### PR DESCRIPTION
Buckets other than us-east-1 incorrectly had `s3-` prepended, where it should have been `s3.`

https://s3-af-south-1.amazonaws.com/bucket-name

which should be

https://s3.af-south-1.amazonaws.com/bucket-name