### PR TITLE
[BugFix] S3 Class to String Fix 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
       "role": "Maintainer"
     }
   ],
-  "require": {},
+  "require": {
+    "php": ">=5.4.0",
+    "ext-fileinfo": "*",
+    "ext-imagick": "*"
+  },
   "autoload": {
     "psr-0": {
         "FroalaEditor": "lib/"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "froala/wysiwyg-editor-php-sdk",
-  "version": "4.0.18",
+  "version": "4.0.17",
   "description": "PHP SDK for Froala WYSIWYG Editor",
   "type": "php-plugin",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "froala/wysiwyg-editor-php-sdk",
-  "version": "4.0.17",
+  "version": "4.0.18",
   "description": "PHP SDK for Froala WYSIWYG Editor",
   "type": "php-plugin",
   "keywords": [

--- a/lib/FroalaEditor.php
+++ b/lib/FroalaEditor.php
@@ -8,7 +8,7 @@
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'autoload.php');
 
 if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-    throw new Braintree_Exception('PHP version >= 5.4.0 required');
+    throw new Exception('PHP version >= 5.4.0 required');
 }
 
 function requireDependencies() {

--- a/lib/FroalaEditor/S3.php
+++ b/lib/FroalaEditor/S3.php
@@ -92,7 +92,7 @@ class S3 {
     // Prepare response.
     $response = new \StdClass;
     $response->bucket = $bucket;
-    $response->region = $region != 'us-east-1' ? 's3-' . $region : 's3';
+    $response->region = $region != 'us-east-1' ? 's3.' . $region : 's3';
     $response->keyStart = $keyStart;
 
     // Prepare params.

--- a/lib/FroalaEditor/S3.php
+++ b/lib/FroalaEditor/S3.php
@@ -113,7 +113,7 @@ class S3 {
     // Set params in response.
     $response->params = $params;
 
-    return $response;
+    return json_encode($response);
   }
 }
 


### PR DESCRIPTION
In PHP version 8.1 and above the S3 upload functionality was found to be breaking. Here as the fix:

- echo of $class object was no longer supported in higher versions of PHP. So, encoding of the configuration having the hashes for S3 file upload is done. 
- A increase in the version number for pushing the package to packagist. 

